### PR TITLE
Close picker

### DIFF
--- a/demo/karma.conf.js
+++ b/demo/karma.conf.js
@@ -4,18 +4,18 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', 'angular-cli'],
+    frameworks: ['jasmine', '@angular/cli'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-remap-istanbul'),
-      require('angular-cli/plugins/karma')
+      require('@angular/cli/plugins/karma')
     ],
     files: [
       { pattern: './src/test.ts', watched: false }
     ],
     preprocessors: {
-      './src/test.ts': ['angular-cli']
+      './src/test.ts': ['@angular/cli']
     },
     mime: {
       'text/x-typescript': ['ts','tsx']
@@ -27,7 +27,7 @@ module.exports = function (config) {
       }
     },
     angularCli: {
-      config: './angular-cli.json',
+      config: './@angular/cli.json',
       environment: 'dev'
     },
     reporters: config.angularCli && config.angularCli.codeCoverage

--- a/ngx-datetimepicker/karma.conf.js
+++ b/ngx-datetimepicker/karma.conf.js
@@ -4,18 +4,18 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', 'angular-cli'],
+    frameworks: ['jasmine', '@angular/cli'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-remap-istanbul'),
-      require('angular-cli/plugins/karma')
+      require('@angular/cli/plugins/karma')
     ],
     files: [
       { pattern: './src/test.ts', watched: false }
     ],
     preprocessors: {
-      './src/test.ts': ['angular-cli']
+      './src/test.ts': ['@angular/cli']
     },
     mime: {
       'text/x-typescript': ['ts','tsx']
@@ -27,7 +27,7 @@ module.exports = function (config) {
       }
     },
     angularCli: {
-      config: './angular-cli.json',
+      config: './@angular/cli.json',
       environment: 'dev'
     },
     reporters: config.angularCli && config.angularCli.codeCoverage

--- a/ngx-datetimepicker/src/app/date.component/date.component.html
+++ b/ngx-datetimepicker/src/app/date.component/date.component.html
@@ -51,6 +51,6 @@
 			></ngx-time>
 	<div class="calendar--footer">
 		<button class="calendar--btn calendar--btn__now" (click)="setSelectedDate(null); showMonthSelection = false; showYearSelection = false">Now</button>
-		<button class="calendar--btn calendar--btn__done" (click)="closePicker()">Close</button>
+		<button class="calendar--btn calendar--btn__close" (click)="closePicker()">Close</button>
 	</div>
 </div>

--- a/ngx-datetimepicker/src/app/date.component/date.component.html
+++ b/ngx-datetimepicker/src/app/date.component/date.component.html
@@ -51,6 +51,6 @@
 			></ngx-time>
 	<div class="calendar--footer">
 		<button class="calendar--btn calendar--btn__now" (click)="setSelectedDate(null); showMonthSelection = false; showYearSelection = false">Now</button>
-		<button class="calendar--btn calendar--btn__done">Done</button>
+		<button class="calendar--btn calendar--btn__done" (click)="closePicker()">Close</button>
 	</div>
 </div>

--- a/ngx-datetimepicker/src/app/date.component/date.component.spec.ts
+++ b/ngx-datetimepicker/src/app/date.component/date.component.spec.ts
@@ -104,6 +104,13 @@ describe('a date component', () => {
 		expect(dateComponent.showYearSelection).toBe(false);
 	});
 
+	it('should tell the picker to hide when closed', () => {
+		dateComponent.closeDatePicker.subscribe(visiblility => {
+			expect(visiblility).toBe(false);
+		})
+		dateComponent.closePicker();
+	});
+
 	describe('time component', () => {
 		it('should change the selected time to 8pm', (done) => {
 			dateComponent.ngOnInit();

--- a/ngx-datetimepicker/src/app/date.component/date.component.ts
+++ b/ngx-datetimepicker/src/app/date.component/date.component.ts
@@ -13,6 +13,7 @@ export class DateComponent implements OnInit {
     @Input() includeTime: boolean;
 
     @Output() selectedDateChange = new EventEmitter<Date>();
+    @Output() closeDatePicker = new EventEmitter<boolean>();
 
     @ViewChild('yearSelect') yearSelect: ElementRef;
     @ViewChild('monthSelect') monthSelect: ElementRef;
@@ -179,5 +180,9 @@ export class DateComponent implements OnInit {
     public toggleYearMenu(): void {
         this.scrollToYear();
         this.showYearSelection = !this.showYearSelection;
+    }
+
+    public closePicker(): void {
+        this.closeDatePicker.emit(false);
     }
 }

--- a/ngx-datetimepicker/src/app/date.component/date.component.ts
+++ b/ngx-datetimepicker/src/app/date.component/date.component.ts
@@ -93,6 +93,8 @@ export class DateComponent implements OnInit {
         this.highlightedDate = this.selectedDate;
         this.selectedHour = date.getHours();
         this.selectedMinute = date.getMinutes();
+
+        this.closePicker();
     }
 
     private loadCalendarMonth(date: Date) {

--- a/ngx-datetimepicker/src/app/datePicker.component/datePicker.component.html
+++ b/ngx-datetimepicker/src/app/datePicker.component/datePicker.component.html
@@ -10,7 +10,7 @@
           <path fill="#000000" d="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z" />
         </svg>
       </button>
-      <ngx-date *ngIf="pickerVisible" (selectedDateChange)="newDatePicked($event)" [selectedDate]="selectedDate"> </ngx-date>
+      <ngx-date *ngIf="pickerVisible" (closeDatePicker)="closePicker($event)" (selectedDateChange)="newDatePicked($event)" [selectedDate]="selectedDate"> </ngx-date>
     </div>
   </div>
 </div>

--- a/ngx-datetimepicker/src/app/datePicker.component/datePicker.component.spec.ts
+++ b/ngx-datetimepicker/src/app/datePicker.component/datePicker.component.spec.ts
@@ -25,4 +25,12 @@ describe('a input component', () => {
 		expect(datePickerComponent.selectedDate.getFullYear()).toEqual(new Date().getFullYear());
 	});
 
+	it('should hide the picker', () => {
+		let visibility = false;
+
+		datePickerComponent.closePicker(visibility);
+
+		expect(datePickerComponent.pickerVisible).toBe(false);
+	});
+
 });

--- a/ngx-datetimepicker/src/app/datePicker.component/datePicker.component.ts
+++ b/ngx-datetimepicker/src/app/datePicker.component/datePicker.component.ts
@@ -46,4 +46,7 @@ export class DatePickerComponent implements OnInit {
         this.selectedDate = date;
     }
 
+    closePicker(close: boolean): void {
+        this.pickerVisible = close;
+    }
 }

--- a/ngx-datetimepicker/src/app/dateTimePicker.component/dateTimePicker.component.html
+++ b/ngx-datetimepicker/src/app/dateTimePicker.component/dateTimePicker.component.html
@@ -10,7 +10,7 @@
             <path fill="#000000" d="M15,13H16.5V15.82L18.94,17.23L18.19,18.53L15,16.69V13M19,8H5V19H9.67C9.24,18.09 9,17.07 9,16A7,7 0 0,1 16,9C17.07,9 18.09,9.24 19,9.67V8M5,21C3.89,21 3,20.1 3,19V5C3,3.89 3.89,3 5,3H6V1H8V3H16V1H18V3H19A2,2 0 0,1 21,5V11.1C22.24,12.36 23,14.09 23,16A7,7 0 0,1 16,23C14.09,23 12.36,22.24 11.1,21H5M16,11.15A4.85,4.85 0 0,0 11.15,16C11.15,18.68 13.32,20.85 16,20.85A4.85,4.85 0 0,0 20.85,16C20.85,13.32 18.68,11.15 16,11.15Z" />
           </svg>
         </button>
-        <ngx-date [hidden]="!pickerVisible" includeTime="true" (selectedDateChange)="newDatePicked($event)" [selectedDate]="selectedDateTime"> </ngx-date>
+        <ngx-date [hidden]="!pickerVisible" includeTime="true" (closeDatePicker)="closePicker($event)" (selectedDateChange)="newDatePicked($event)" [selectedDate]="selectedDateTime"> </ngx-date>
       </div>
   </div>
 </div>

--- a/ngx-datetimepicker/src/app/dateTimePicker.component/dateTimePicker.component.spec.ts
+++ b/ngx-datetimepicker/src/app/dateTimePicker.component/dateTimePicker.component.spec.ts
@@ -27,4 +27,12 @@ describe('a input component', () => {
 		expect(dateTimePickerComponent.selectedDateTime.getMinutes()).toEqual(0);
 	});
 
+	it('should hide the picker', () => {
+		let visibility = false;
+
+		dateTimePickerComponent.closePicker(visibility);
+
+		expect(dateTimePickerComponent.pickerVisible).toBe(false);
+	});
+
 });

--- a/ngx-datetimepicker/src/app/dateTimePicker.component/dateTimePicker.component.ts
+++ b/ngx-datetimepicker/src/app/dateTimePicker.component/dateTimePicker.component.ts
@@ -49,4 +49,8 @@ export class DateTimePickerComponent implements OnInit {
         this.selectedDateTimeChange.emit(date);
         this.selectedDateTime = date;
     }
+
+    closePicker(close: boolean): void {
+        this.pickerVisible = close;
+    }
 }

--- a/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.html
+++ b/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.html
@@ -14,7 +14,7 @@
 				<ngx-time [selectedHour]="selectedHour" [selectedMinute]="selectedMinute" (selectedHourChange)="selectedHour = $event" (selectedMinuteChange)="selectedMinute = $event"></ngx-time>
 				<div class="calendar--footer">
 					<button class="calendar--btn calendar--btn__now" (click)="setTimeToNow()">Now</button>
-					<button class="calendar--btn calendar--btn__done">Done</button>
+					<button class="calendar--btn calendar--btn__done" (click)="closePicker()">Close</button>
 				</div>
 			</div>
 		</div>

--- a/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.html
+++ b/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.html
@@ -14,7 +14,7 @@
 				<ngx-time [selectedHour]="selectedHour" [selectedMinute]="selectedMinute" (selectedHourChange)="selectedHour = $event" (selectedMinuteChange)="selectedMinute = $event"></ngx-time>
 				<div class="calendar--footer">
 					<button class="calendar--btn calendar--btn__now" (click)="setTimeToNow()">Now</button>
-					<button class="calendar--btn calendar--btn__done" (click)="closePicker()">Close</button>
+					<button class="calendar--btn calendar--btn__close" (click)="closePicker()">Close</button>
 				</div>
 			</div>
 		</div>

--- a/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.spec.ts
+++ b/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.spec.ts
@@ -44,4 +44,10 @@ describe('a timePicker component', () => {
 		expect(timePickerComponent.selectedHour).toBe(now.getHours());
 		expect(timePickerComponent.selectedMinute).toBe(now.getMinutes());
 	});
+
+	it('should hide the picker when closed', () => {
+		timePickerComponent.closePicker();
+
+		expect(timePickerComponent.pickerVisible).toBe(false);
+	})
 });

--- a/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.ts
+++ b/ngx-datetimepicker/src/app/timePicker.component/timePicker.component.ts
@@ -68,4 +68,8 @@ export class TimePickerComponent implements OnInit {
 		this.selectedHour = now.getHours();
 		this.selectedMinute = now.getMinutes();
 	}
+
+	closePicker(): void {
+		this.pickerVisible = false;
+	}
 }

--- a/sass/_date.scss
+++ b/sass/_date.scss
@@ -48,7 +48,7 @@
 
 .calendar--btn__month:hover { border-top-left-radius: $base-border-radius; }
 
-.calendar--btn__done:hover { border-bottom-right-radius: $base-border-radius; }
+.calendar--btn__close:hover { border-bottom-right-radius: $base-border-radius; }
 
 .calendar--btn__now:hover { border-bottom-left-radius: $base-border-radius; }
 


### PR DESCRIPTION
Switched the 'Done' button to 'Close'.

It just closes the picker without saving any of the current selections. This means the only way to save a date/time is to select either a day, an hour, a minute, or press the 'Now' button.