### PR TITLE
updating the peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "typescript": "~2.2.2"
   },
   "peerDependencies": {
-    "@angular/common": "4.0.0",
-    "@angular/compiler": "4.0.0",
-    "@angular/core": "4.0.0",
-    "@angular/forms": "4.0.0",
-    "@angular/platform-browser": "4.0.0",
-    "@angular/platform-browser-dynamic": "4.0.0"
+    "@angular/common": "4.x",
+    "@angular/compiler": "4.x",
+    "@angular/core": "4.x",
+    "@angular/forms": "4.x",
+    "@angular/platform-browser": "4.x",
+    "@angular/platform-browser-dynamic": "4.x"
   }
 }


### PR DESCRIPTION
updating these so they are not tied to a spefic version of angular 4 but any 4.0 version will do.

addresses issue https://github.com/RenovoSolutions/ngx-datetimepicker/issues/34