### PR TITLE
Mock ngModel for app tests

### DIFF
--- a/ngx-datetimepicker/src/app/app.component.spec.ts
+++ b/ngx-datetimepicker/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:no-unused-variable */
 
+import { Directive, Input, Output, EventEmitter } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { DateComponent } from './date.component/date.component';
@@ -10,6 +11,12 @@ import { TimeComponent } from './time.component/time.component';
 import { DateTimePickerComponent } from './dateTimePicker.component/dateTimePicker.component';
 import { TimePickerComponent } from './timePicker.component/timePicker.component';
 
+@Directive({ selector: '[ngModel]' })
+export class ngModelMock {
+	@Input() ngModel;
+	@Output() ngModelChange = new EventEmitter();
+}
+
 describe('AppComponent', () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
@@ -19,7 +26,8 @@ describe('AppComponent', () => {
 				DatePickerComponent,
 				TimeComponent,
 				DateTimePickerComponent,
-				TimePickerComponent
+				TimePickerComponent,
+				ngModelMock
 			],
 			providers: [
 				IsMobileService,


### PR DESCRIPTION
For the app tests, we need to mock ngModel since this shows up in the app component template. Otherwise the tests throw an error indicating ngModel isn't a valid binding.