### PR TITLE
#91 exporting TimeComponent & DateComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-datetime-picker",
-  "version": "2.1.0",
+  "version": "3.0.1",
   "description": "Date, DateTime & Time Picker components that uses native HTML5 components on mobile",
   "repository": {
     "url": "https://github.com/RenovoSolutions/ngx-datetimepicker"

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ import { Renderer } from './services/renderer.service';
         TimePickerComponent
     ],
     exports: [
+        TimeComponent,
+        DateComponent,
         DatePickerComponent,
         DateTimePickerComponent,
         TimePickerComponent


### PR DESCRIPTION
`TimeComponent`, `DateComponent` are exported in `DateTimePickerModule` so they are reachable outside of the library.